### PR TITLE
Update to assume Python 3.6, not 3.4

### DIFF
--- a/prepare_lambda_upload.sh
+++ b/prepare_lambda_upload.sh
@@ -1,5 +1,5 @@
 rm -rf ../redash-emailer.zip
 zip ../redash-emailer.zip ./*.py
-cd ./venv/lib/python3.4/site-packages/
+cd ./venv/lib/python3.6/site-packages/
 zip -r9 ../../../../../redash-emailer.zip *
 cd ../../../../


### PR DESCRIPTION
At some point we should figure out how to replace this with Zappa, but the current Cloud Watch setup doesn't work with Zappa.