### PR TITLE
Use Zappa for Lambda deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ settings.py
 __pycache__
 *.pyc
 venv
+zappa_settings.json

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Redash Emailer
 
-This Python 3 script fetches Redash query results and sends them via email as CSV attachment.
+This Python 3.6 script fetches Redash query results and sends them via email as CSV attachment.
 
 ## Getting started
 
-* Within a Python 3 environment, run `pip install -r requirements`.
+* Within a Python 3.6 environment, run `pip install -r requirements`.
 * Copy `settings.py.example` to `settings.py`, fill in values.
 * Run `python redash_emailer.py -h` to get input options.
 
@@ -14,4 +14,4 @@ You can set the recipient with either `--to` on the command line, or `TO_ADDRESS
 
 ## Amazon Lambda
 
-Running `./prepare_lambda_upload.sh` from within a working local install will generate a `redash-emailer.zip` file that can be uploaded and run on Amazon Lambda.
+Copy `zappa_settings.json` from 1Password into main directory. Run `zappa update` to update code on Amazon Lambda.

--- a/prepare_lambda_upload.sh
+++ b/prepare_lambda_upload.sh
@@ -1,5 +1,0 @@
-rm -rf ../redash-emailer.zip
-zip ../redash-emailer.zip ./*.py
-cd ./venv/lib/python3.4/site-packages/
-zip -r9 ../../../../../redash-emailer.zip *
-cd ../../../../

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+zappa==0.53.0


### PR DESCRIPTION
I was unable to make the .zip file to upload to Lambda using the `./prepare_lambda_upload.sh` command (because I don't have the `./venv/lib/python3.4/site-packages/` directory)

This PR changes the deployment method to Zappa