### PR TITLE
bring zappa_settings out of gitignore and change runtime to 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ settings.py
 __pycache__
 *.pyc
 venv
-zappa_settings.json
+.python-version

--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -1,0 +1,18 @@
+{
+    "prod": {
+        "app_function": "redash_emailer.aws_lambda",
+        "aws_region": "us-west-1",
+        "profile_name": "default",
+        "project_name": "redash-emailer",
+        "runtime": "python3.9",
+        "s3_bucket": "zappa-fmkb1g17t",
+        "vpc_config": {
+            "SubnetIds": [
+                "subnet-d8385681"
+            ],
+            "SecurityGroupIds": [
+                "sg-c2ee0da5"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Tested the script locally and it looks good, updated the lambda runtime on the aws console and also looked good. The only trouble is that zappa update prod isn't working anymore so I'm unsure on that. I read online that I should delete the lambda and then redeploy it to get the zappa error to go away but it almost looks like it got disconnected somehow from the aws copy:

```
CloudFormation stack missing, re-deploy to enable updates
ERROR:Could not get API ID.
Traceback (most recent call last):
  File "/root/.pyenv/versions/3.9.0/envs/redash-emailer-ve/lib/python3.9/site-packages/zappa/core.py", line 2587, in get_api_id
    response = self.cf_client.describe_stack_resource(
  File "/root/.pyenv/versions/3.9.0/envs/redash-emailer-ve/lib/python3.9/site-packages/botocore/client.py", line 514, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/root/.pyenv/versions/3.9.0/envs/redash-emailer-ve/lib/python3.9/site-packages/botocore/client.py", line 934, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the DescribeStackResource operation: Stack 'redash-emailer-prod' does not exist
Oh no! An error occurred! :(
```

I don't think this is due to any of the changes I made specifically here though