### PR TITLE
Update Zappa Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-zappa==0.54.0
+zappa==0.56.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-zappa==0.53.0
+zappa==0.54.0

--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -5,6 +5,8 @@
         "profile_name": "default",
         "project_name": "redash-emailer",
         "runtime": "python3.9",
+        "cloudwatch_log_level": "INFO",
+        "log_level": "INFO",
         "s3_bucket": "zappa-fmkb1g17t",
         "vpc_config": {
             "SubnetIds": [


### PR DESCRIPTION
I found that I needed to update Zappa before I was able to re-deploy with the new API key. I also updated log level to INFO.